### PR TITLE
Add OpenAI-compatible provider

### DIFF
--- a/docs/LLM providers.md
+++ b/docs/LLM providers.md
@@ -23,3 +23,20 @@ Features:
 
 - ✅ Streaming responses
 - ✅ Chat and embedding models
+
+### OpenAI-compatible
+
+This provider allows connecting to an API that offers OpenAI-compatible LLM APIs, served by arbitrary models.
+
+Features:
+
+- ✅ Streaming responses
+- ✅ Chat and embedding models
+- ✅ Custom base URL
+
+Configuration:
+
+- Server URL: The base URL of the OpenAI-compatible API.
+- API Key: The access token for the OpenAI-compatible API.
+
+To configure the OpenAI-compatible provider, go to the plugin settings and enter the Server URL and API Key. You can then list available models and select one for use.

--- a/src/component/settings/OpenAICompatibleSettingsDialog.svelte
+++ b/src/component/settings/OpenAICompatibleSettingsDialog.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+	import type { ModelConfiguration } from "src/config/settings"
+	import { pluginStore } from "src/utils/obsidian"
+	import { slide } from "svelte/transition"
+	import ErrorComponent from "../ErrorComponent.svelte"
+	import Loading from "../obsidian/Loading.svelte"
+	import ObsidianIcon from "../obsidian/ObsidianIcon.svelte"
+	import type { DialogProps } from "./types"
+	import { onMount } from "svelte"
+	import { testConnection } from "src/rag/llm/openai"
+
+	let { currentModel, feature, closeDialog }: DialogProps = $props()
+
+	let url = $state("http://localhost:11434")
+	let apiKey = $state($pluginStore.settings.providerSettings.openaiCompatible?.apiKey ?? "")
+	let selectedModel = $state(currentModel ?? "")
+
+	let loading = $state(false)
+	let localModels: string[] | null = $state(null)
+	let loadError: string | null = $state(null)
+
+	onMount(() => {
+		if (url && url != "") {
+			// Pre-populate model list if a URL is already set
+			testConnection()
+		}
+	})
+
+	const testConnection = async () => {
+		try {
+			loading = true
+			loadError = null
+			localModels = []
+			const models = await listLoadableModels(url)
+			localModels = models.models.map((m) => m.name)
+
+			if (models.models.length === 1) {
+				selectedModel = models.models[0].name
+			}
+		} catch (e: any) {
+			localModels = []
+			loadError = e.toString()
+		} finally {
+			loading = false
+		}
+	}
+
+	const saveSettings = () => {
+		$pluginStore.settings = {
+			...$pluginStore.settings,
+			providerSettings: {
+				...$pluginStore.settings.providerSettings,
+				openaiCompatible: {
+					url,
+					apiKey,
+				},
+			},
+		}
+
+		if (feature) {
+			const newConfig: ModelConfiguration = {
+				provider: "OpenAICompatible",
+				model: selectedModel,
+			}
+			switch (feature) {
+				case "questionAndAnswer":
+					$pluginStore.settings = {
+						...$pluginStore.settings,
+						questionAndAnswerModel: newConfig,
+					}
+					break
+				case "noteContext":
+					$pluginStore.settings = {
+						...$pluginStore.settings,
+						noteContextModel: newConfig,
+					}
+					break
+				case "embedding":
+					$pluginStore.settings = {
+						...$pluginStore.settings,
+						embeddingModel: newConfig,
+					}
+					break
+				default:
+					throw new Error("Tried to save settings for unknown feature: " + feature)
+			}
+		}
+
+		$pluginStore.saveSettings()
+
+		closeDialog()
+	}
+</script>
+
+<div>
+	<label for="url" class="mb-2 block font-medium">Server URL</label>
+	<input id="url" class="w-80" type="text" placeholder="Server URL" bind:value={url} />
+	<label for="apiKey" class="mb-2 block font-medium">API Key</label>
+	<input id="apiKey" class="w-80" type="password" placeholder="API Key" bind:value={apiKey} />
+	<button class="ml-4" onclick={() => testConnection()}>
+		{#if feature}
+			List models
+		{:else}
+			Test connection
+		{/if}
+	</button>
+	{#if localModels && localModels.length === 0 }
+		<div class="my-4">
+			No models found. Make sure your OpenAI-compatible instance has some models available.
+		</div>
+	{:else if localModels && localModels.length > 0}
+		<ObsidianIcon iconId="check" size="l" color="success" className="ml-2 relative top-1" />
+	{/if}
+
+	{#if loading}
+		<Loading size="s" />
+	{:else if loadError !== null}
+		<div class="my-4">
+			<ErrorComponent title="Connection error" body={loadError} />
+		</div>
+	{/if}
+
+	{#if feature}
+		<label for="model" class="mb-2 mt-4 block font-medium">
+			{#if feature === "questionAndAnswer"}
+				Model for conversations
+			{:else if feature === "noteContext"}
+				Model for note context
+			{:else if feature === "embedding"}
+				Model for embeddings
+			{/if}
+		</label>
+		<input id="model" class="w-80" type="text" placeholder="Model" bind:value={selectedModel} />
+		<button class="mod-cta ml-4" onclick={saveSettings} disabled={selectedModel.trim() === ""}
+			>Select model
+		</button>
+
+		{#if localModels && localModels.length > 1}
+			<div class="text-sm" transition:slide={{ axis: "y", duration: 200 }}>
+				<p>Available models:</p>
+				<ul>
+					{#each localModels as model}
+						<!-- svelte-ignore a11y_click_events_have_key_events -->
+						<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+						<li
+							class="cursor-pointer select-text font-mono my-1"
+							onclick={() => (selectedModel = model)}
+						>
+							{model}
+						</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+	{/if}
+</div>

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,9 +1,10 @@
-export type Provider = "OpenAI" | "Anthropic" | "Ollama"
+export type Provider = "OpenAI" | "Anthropic" | "Ollama" | "OpenAICompatible"
 
 export interface ProviderSettings {
 	openai: OpenAISettings
 	anthropic: AnthropicSettings
 	ollama: OllamaSettings
+	openaiCompatible: OpenAICompatibleSettings
 }
 
 export interface OllamaSettings {
@@ -15,5 +16,10 @@ export interface OpenAISettings {
 }
 
 export interface AnthropicSettings {
+    apiKey: string
+}
+
+export interface OpenAICompatibleSettings {
+    url: string
     apiKey: string
 }

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -54,6 +54,10 @@ export const DEFAULT_SETTINGS: LlmPluginSettings = {
 		ollama: {
 			url: "",
 		},
+		openaiCompatible: {
+			url: "",
+			apiKey: "",
+		},
 	},
 }
 
@@ -64,9 +68,11 @@ export const MODEL_CONFIGS: ModelConfiguration[] = [
 	{ provider: "Anthropic", model: "claude-3-7-sonnet-20250219" },
 	{ provider: "Anthropic", model: "claude-sonnet-4-20250514" },
 	{ provider: "Anthropic", model: "claude-opus-4-20250514" },
+	{ provider: "OpenAICompatible", model: "openai-compatible-model" },
 ]
 
 export const EMBEDDING_MODEL_CONFIGS: ModelConfiguration[] = [
 	{ provider: "OpenAI", model: "text-embedding-3-small" },
 	{ provider: "OpenAI", model: "text-embedding-3" },
+	{ provider: "OpenAICompatible", model: "openai-compatible-embedding" },
 ]

--- a/src/llm-features/embedding-client.ts
+++ b/src/llm-features/embedding-client.ts
@@ -22,6 +22,13 @@ export const embeddingClient = derived(
 					modelConfig.model,
 					$llmClient,
 				)
+			case "OpenAICompatible":
+				return new OpenAIEmbeddingClient(
+					$settingsStore.providerSettings.openaiCompatible.apiKey,
+					modelConfig.model,
+					$llmClient,
+					$settingsStore.providerSettings.openaiCompatible.url,
+				)
 			default:
 				throw new Error("Unrecognized provider: " + provider)
 		}

--- a/src/llm-features/llm-client.ts
+++ b/src/llm-features/llm-client.ts
@@ -27,6 +27,12 @@ export const llmClient = derived<Writable<LlmPluginSettings>, StreamingChatCompl
 					$settingsStore.providerSettings.ollama.url,
 					modelConfig.model,
 				)
+			case "OpenAICompatible":
+				return new OpenAIChatCompletionClient(
+					$settingsStore.providerSettings.openaiCompatible.apiKey,
+					modelConfig.model,
+					$settingsStore.providerSettings.openaiCompatible.url,
+				)
 			default:
 				throw new Error("Unrecognized provider: " + provider)
 		}

--- a/src/rag/llm/openai.ts
+++ b/src/rag/llm/openai.ts
@@ -12,8 +12,8 @@ import {
 	type Temperature,
 } from "./common"
 
-export const testConnection = async (apiKey: string): Promise<boolean> => {
-	const client = new OpenAI({ apiKey, dangerouslyAllowBrowser: true })
+export const testConnection = async (apiKey: string, baseUrl?: string): Promise<boolean> => {
+	const client = new OpenAI({ apiKey, baseURL: baseUrl, dangerouslyAllowBrowser: true })
 	const list = await client.models.list()
 	return list.data.length > 0
 }
@@ -23,8 +23,8 @@ export class OpenAIChatCompletionClient implements StreamingChatCompletionClient
 	private apiKey: string
 	private model: string
 
-	constructor(apiKey: string, model: string) {
-		this.client = new OpenAI({ apiKey, dangerouslyAllowBrowser: true })
+	constructor(apiKey: string, model: string, baseUrl?: string) {
+		this.client = new OpenAI({ apiKey, baseURL: baseUrl, dangerouslyAllowBrowser: true })
 		this.apiKey = apiKey
 		this.model = model
 	}
@@ -150,8 +150,8 @@ export class OpenAIEmbeddingClient implements EmbeddingClient {
 	private apiKey: string
 	private embeddingModel: string
 
-	constructor(apiKey: string, embeddingModel: string, chatClient: ChatCompletionClient) {
-		this.openaiClient = new OpenAI({ apiKey, dangerouslyAllowBrowser: true })
+	constructor(apiKey: string, embeddingModel: string, chatClient: ChatCompletionClient, baseUrl?: string) {
+		this.openaiClient = new OpenAI({ apiKey, baseURL: baseUrl, dangerouslyAllowBrowser: true })
 		this.chatClient = chatClient
 		this.apiKey = apiKey
 		this.embeddingModel = embeddingModel

--- a/src/view/Settings.ts
+++ b/src/view/Settings.ts
@@ -3,6 +3,7 @@ import AnthropicSettingsDialog from "src/component/settings/AnthropicSettingsDia
 import EmbeddingChangeDialog from "src/component/settings/EmbeddingChangeDialog.svelte"
 import OllamaSettingsDialog from "src/component/settings/OllamaSettingsDialog.svelte"
 import OpenAiSettingsDialog from "src/component/settings/OpenAISettingsDialog.svelte"
+import OpenAICompatibleSettingsDialog from "src/component/settings/OpenAICompatibleSettingsDialog.svelte"
 import type { DialogProps } from "src/component/settings/types"
 import type { Provider } from "src/config/providers"
 import {
@@ -22,9 +23,10 @@ const PROVIDER_COMPONENT_MAP: Map<Provider, Component<DialogProps>> = new Map([
 	["Ollama", OllamaSettingsDialog],
 	["OpenAI", OpenAiSettingsDialog],
 	["Anthropic", AnthropicSettingsDialog],
+	["OpenAICompatible", OpenAICompatibleSettingsDialog],
 ])
 
-const PROVIDERS_WITH_CUSTOM_SETTINGS = new Set<Provider>(["Ollama"])
+const PROVIDERS_WITH_CUSTOM_SETTINGS = new Set<Provider>(["Ollama", "OpenAICompatible"])
 
 export class LlmSettingTab extends PluginSettingTab {
 	plugin: LlmPlugin
@@ -57,6 +59,9 @@ export class LlmSettingTab extends PluginSettingTab {
 			.addButton((button) => {
 				button.setButtonText("Ollama").onClick(() => {
 					this.openProviderSettingsModal("Ollama", null)
+				})
+				button.setButtonText("OpenAICompatible").onClick(() => {
+					this.openProviderSettingsModal("OpenAICompatible", null)
 				})
 			})
 


### PR DESCRIPTION
Add support for "OpenAI-compatible" LLM provider.

* **Configuration Changes**
  - Add `OpenAICompatibleSettings` interface with `url` and `apiKey` fields in `src/config/providers.ts`.
  - Update `Provider` type and `ProviderSettings` interface to include `OpenAICompatible`.
  - Update `DEFAULT_SETTINGS`, `MODEL_CONFIGS`, and `EMBEDDING_MODEL_CONFIGS` in `src/config/settings.ts` to include `OpenAICompatible` models.

* **UI Changes**
  - Create `OpenAICompatibleSettingsDialog.svelte` component for configuring OpenAI-compatible settings.
  - Add entry for `OpenAICompatible` in the settings tab in `src/view/Settings.ts`.

* **Client Changes**
  - Add case for `OpenAICompatible` in `embeddingClient` and `llmClient` derived stores in `src/llm-features/embedding-client.ts` and `src/llm-features/llm-client.ts`.
  - Implement logic to create instances of `OpenAIEmbeddingClient` and `OpenAIChatCompletionClient` with custom base URL.

* **API Changes**
  - Update `OpenAIChatCompletionClient` and `OpenAIEmbeddingClient` constructors in `src/rag/llm/openai.ts` to accept a base URL.
  - Modify client initialization to use the provided base URL.

* **Documentation**
  - Add section for `OpenAI-compatible` provider in `docs/LLM providers.md`.
  - Document features and configuration options for the `OpenAI-compatible` provider.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ofalvai/obsidian-llm-workspace/pull/99?shareId=6ad223d9-e0b0-4bc5-ac81-a4f39da8b86a).